### PR TITLE
feat: 브랜딩 에셋 업로드 기능 추가 (Presigned URL)

### DIFF
--- a/src/components/settings/BrandingUploader.tsx
+++ b/src/components/settings/BrandingUploader.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useRef, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { useBrandingUpload } from '@/hooks/use-branding-upload';
+import { BrandingType } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+interface BrandingUploaderProps {
+  type: BrandingType;
+  title: string;
+  description: string;
+  currentUrl: string | null;
+  updatedAt?: string;
+  onCommit?: () => void;
+}
+
+// 타입별 검증 규칙
+const VALIDATION_RULES: Record<
+  BrandingType,
+  {
+    maxSize: number;
+    allowedTypes: string[];
+    accept: string;
+  }
+> = {
+  logo: {
+    maxSize: 2 * 1024 * 1024, // 2MB
+    allowedTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/svg+xml'],
+    accept: 'image/png,image/jpeg,image/webp,image/svg+xml',
+  },
+  favicon: {
+    maxSize: 512 * 1024, // 512KB
+    allowedTypes: ['image/png', 'image/x-icon', 'image/vnd.microsoft.icon'],
+    accept: 'image/png,image/x-icon,.ico',
+  },
+  og: {
+    maxSize: 5 * 1024 * 1024, // 5MB
+    allowedTypes: ['image/png', 'image/jpeg', 'image/webp'],
+    accept: 'image/png,image/jpeg,image/webp',
+  },
+};
+
+export function BrandingUploader({
+  type,
+  title,
+  description,
+  currentUrl,
+  updatedAt,
+  onCommit,
+}: BrandingUploaderProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { state, upload, commit, reset, isUploading, isUploaded, isCommitting } =
+    useBrandingUpload(type);
+
+  const rules = VALIDATION_RULES[type];
+
+  // 표시할 이미지 URL (업로드 중이면 tmp, 아니면 현재 URL)
+  const displayUrl = state.tmpPreviewUrl || currentUrl;
+  // 캐시 버스트 적용 (tmp URL은 이미 유니크하므로 버스트 불필요)
+  const imageUrl = displayUrl
+    ? state.tmpPreviewUrl
+      ? displayUrl
+      : `${displayUrl}?v=${updatedAt || ''}`
+    : null;
+
+  const handleFileSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+
+      // 파일 크기 검증
+      if (file.size > rules.maxSize) {
+        alert(`파일 크기는 최대 ${Math.floor(rules.maxSize / 1024)}KB까지 가능합니다.`);
+        return;
+      }
+
+      // MIME 타입 검증
+      if (!rules.allowedTypes.includes(file.type)) {
+        alert('지원하지 않는 파일 형식입니다.');
+        return;
+      }
+
+      try {
+        await upload(file);
+      } catch {
+        // 에러는 state.error로 표시됨
+      }
+
+      // input 초기화
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    },
+    [upload, rules],
+  );
+
+  const handleReplace = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleRemove = useCallback(() => {
+    reset();
+  }, [reset]);
+
+  const handleSave = useCallback(async () => {
+    try {
+      await commit();
+      onCommit?.();
+    } catch {
+      // 에러는 state.error로 표시됨
+    }
+  }, [commit, onCommit]);
+
+  return (
+    <div className="flex items-start justify-between py-4 border-b border-gray-100 last:border-b-0">
+      {/* 왼쪽: 정보 + 버튼 */}
+      <div className="flex-1">
+        <h3 className="text-sm font-medium text-gray-900">{title}</h3>
+        <p className="text-xs text-gray-500 mt-0.5">{description}</p>
+
+        <div className="flex items-center gap-2 mt-3">
+          {/* 숨겨진 file input */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={rules.accept}
+            onChange={handleFileSelect}
+            className="hidden"
+          />
+
+          {isUploaded ? (
+            <>
+              <Button type="button" size="sm" onClick={handleSave} disabled={isCommitting}>
+                {isCommitting ? '적용 중...' : '지금 적용하기'}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleRemove}
+                disabled={isCommitting}
+              >
+                취소
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleReplace}
+                disabled={isUploading}
+              >
+                {isUploading ? '업로드 중...' : currentUrl ? '변경' : '업로드'}
+              </Button>
+              {currentUrl && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleRemove}
+                  disabled={isUploading}
+                >
+                  삭제
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* 에러 메시지 */}
+        {state.error && <p className="text-xs text-red-500 mt-2">{state.error}</p>}
+
+        {/* 업로드 진행률 */}
+        {isUploading && state.progress > 0 && (
+          <div className="mt-2 w-32 h-1 bg-gray-200 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-blue-500 transition-all duration-300"
+              style={{ width: `${state.progress}%` }}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* 오른쪽: 이미지 미리보기 */}
+      <div
+        className={cn(
+          'shrink-0 ml-4 rounded-lg border border-gray-200 bg-gray-50 overflow-hidden flex items-center justify-center',
+          type === 'logo' && 'w-24 h-10',
+          type === 'favicon' && 'w-12 h-12',
+          type === 'og' && 'w-32 h-[68px]',
+        )}
+      >
+        {imageUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={imageUrl}
+            alt={title}
+            className="max-w-full max-h-full object-contain"
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
+          />
+        ) : (
+          <div className="text-gray-300">
+            <PlaceholderIcon type={type} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PlaceholderIcon({ type }: { type: BrandingType }) {
+  if (type === 'favicon') {
+    return (
+      <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+        <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+    </svg>
+  );
+}

--- a/src/hooks/use-branding-upload.ts
+++ b/src/hooks/use-branding-upload.ts
@@ -1,0 +1,148 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  presignBrandingUpload,
+  commitBrandingUpload,
+  BrandingType,
+  BrandingPresignResponse,
+} from '@/lib/api';
+import { getErrorDisplayMessage } from '@/lib/error-handler';
+import { uploadFileToS3 } from './use-upload';
+
+export interface BrandingUploadState {
+  status: 'idle' | 'uploading' | 'uploaded' | 'committing' | 'error';
+  progress: number;
+  tmpPreviewUrl?: string;
+  tmpKey?: string;
+  error?: string;
+}
+
+const initialState: BrandingUploadState = {
+  status: 'idle',
+  progress: 0,
+};
+
+/**
+ * 브랜딩 에셋 업로드 훅
+ */
+export function useBrandingUpload(type: BrandingType) {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<BrandingUploadState>(initialState);
+
+  // Presign mutation
+  const presignMutation = useMutation({
+    mutationFn: presignBrandingUpload,
+  });
+
+  // Commit mutation
+  const commitMutation = useMutation({
+    mutationFn: commitBrandingUpload,
+    onSuccess: () => {
+      // 설정 캐시 무효화 (모든 siteSettings 관련 쿼리)
+      queryClient.invalidateQueries({ queryKey: ['siteSettings'], exact: false });
+    },
+  });
+
+  /**
+   * 파일 업로드 (presign → S3 PUT)
+   */
+  const upload = useCallback(
+    async (file: File) => {
+      setState({
+        status: 'uploading',
+        progress: 0,
+      });
+
+      try {
+        // 1. Presign 요청
+        const presignResponse: BrandingPresignResponse = await presignMutation.mutateAsync({
+          type,
+          filename: file.name,
+          size: file.size,
+          mimeType: file.type,
+        });
+
+        // 2. S3에 직접 업로드
+        await uploadFileToS3(presignResponse.uploadUrl, file, file.type, (progress) => {
+          setState((prev) => ({
+            ...prev,
+            progress,
+          }));
+        });
+
+        // 3. 업로드 완료 상태
+        setState({
+          status: 'uploaded',
+          progress: 100,
+          tmpPreviewUrl: presignResponse.tmpPublicUrl,
+          tmpKey: presignResponse.tmpKey,
+        });
+
+        return presignResponse;
+      } catch (error) {
+        const errorMessage = getErrorDisplayMessage(error, '파일 업로드에 실패했습니다.');
+        setState({
+          status: 'error',
+          progress: 0,
+          error: errorMessage,
+        });
+        throw error;
+      }
+    },
+    [type, presignMutation],
+  );
+
+  /**
+   * 업로드 확정 (commit)
+   */
+  const commit = useCallback(async () => {
+    if (!state.tmpKey) {
+      throw new Error('업로드된 파일이 없습니다.');
+    }
+
+    setState((prev) => ({
+      ...prev,
+      status: 'committing',
+    }));
+
+    try {
+      const response = await commitMutation.mutateAsync({
+        type,
+        tmpKey: state.tmpKey,
+      });
+
+      // 완료 후 상태 초기화
+      setState(initialState);
+
+      return response;
+    } catch (error) {
+      const errorMessage = getErrorDisplayMessage(error, '저장에 실패했습니다.');
+      setState((prev) => ({
+        ...prev,
+        status: 'error',
+        error: errorMessage,
+      }));
+      throw error;
+    }
+  }, [type, state.tmpKey, commitMutation]);
+
+  /**
+   * 상태 초기화 (취소)
+   */
+  const reset = useCallback(() => {
+    setState(initialState);
+  }, []);
+
+  return {
+    state,
+    upload,
+    commit,
+    reset,
+    isUploading: state.status === 'uploading',
+    isUploaded: state.status === 'uploaded',
+    isCommitting: state.status === 'committing',
+    hasChanges: state.status === 'uploaded',
+  };
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -91,6 +91,7 @@ export interface SiteSettings {
   id: string;
   name: string;
   slug: string;
+  updatedAt: string;
   // 브랜딩
   logoImageUrl: string | null;
   faviconUrl: string | null;
@@ -423,6 +424,59 @@ export async function completeUpload(data: CompleteUploadRequest): Promise<Compl
  */
 export async function abortUpload(data: AbortUploadRequest): Promise<void> {
   await api.post('/uploads/abort', data);
+}
+
+// ===== Branding Asset API =====
+
+export type BrandingType = 'logo' | 'favicon' | 'og';
+
+export interface BrandingPresignRequest {
+  type: BrandingType;
+  filename: string;
+  size: number;
+  mimeType: string;
+}
+
+export interface BrandingPresignResponse {
+  uploadUrl: string;
+  tmpPublicUrl: string;
+  tmpKey: string;
+}
+
+export interface BrandingCommitRequest {
+  type: BrandingType;
+  tmpKey: string;
+}
+
+export interface BrandingCommitResponse {
+  publicUrl: string;
+  updatedAt: string;
+}
+
+/**
+ * 브랜딩 에셋 Presigned URL 생성
+ */
+export async function presignBrandingUpload(
+  data: BrandingPresignRequest,
+): Promise<BrandingPresignResponse> {
+  const response = await api.post<ApiResponse<BrandingPresignResponse>>(
+    '/admin/assets/branding/presign',
+    data,
+  );
+  return response.data.data;
+}
+
+/**
+ * 브랜딩 에셋 업로드 확정
+ */
+export async function commitBrandingUpload(
+  data: BrandingCommitRequest,
+): Promise<BrandingCommitResponse> {
+  const response = await api.post<ApiResponse<BrandingCommitResponse>>(
+    '/admin/assets/branding/commit',
+    data,
+  );
+  return response.data.data;
 }
 
 // ===== Category API =====


### PR DESCRIPTION
## 요약

- 로고, 파비콘, OG 이미지를 Presigned URL 방식으로 직접 S3에 업로드하는 기능 추가
- 브랜딩 섹션을 메인 설정 폼에서 분리하여 독립적으로 관리
- 업로드 → 미리보기 → 적용 순서의 2단계 플로우 구현

## 주요 변경사항

### 새 컴포넌트
- `BrandingUploader` - 브랜딩 에셋 업로드 UI 컴포넌트
  - 파일 선택, 미리보기, 적용/취소 버튼
  - 타입별 파일 크기/형식 검증 (로고 2MB, 파비콘 512KB, OG 5MB)
  - 업로드 진행률 표시

### 새 훅
- `useBrandingUpload` - 업로드 상태 관리
  - presign → S3 PUT → commit 플로우
  - 상태: idle / uploading / uploaded / committing / error

### API 추가
- `presignBrandingUpload` - Presigned URL 생성 요청
- `commitBrandingUpload` - 업로드 확정 (tmp → 실제 경로 이동)
- `BrandingType`: 'logo' | 'favicon' | 'og'

### 설정 페이지 변경
- 브랜딩 섹션을 폼 밖으로 분리 (독립 업로드 관리)
- Zod 스키마에서 브랜딩 URL 필드 제거

## 테스트 체크리스트

- [ ] 로고 이미지 업로드 및 미리보기 확인
- [ ] 파비콘 업로드 및 미리보기 확인
- [ ] OG 이미지 업로드 및 미리보기 확인
- [ ] "지금 적용하기" 버튼으로 실제 반영 확인
- [ ] 취소 버튼으로 업로드 취소 확인
- [ ] 잘못된 파일 형식/크기 업로드 시 에러 메시지 확인