### PR TITLE
feat: TipTap 에디터 S3 이미지 업로드 기능 구현

### DIFF
--- a/app/(app)/admin/[siteId]/posts/[postId]/edit/page.tsx
+++ b/app/(app)/admin/[siteId]/posts/[postId]/edit/page.tsx
@@ -331,6 +331,7 @@ export default function EditPostPage() {
                   <FieldLabel>내용</FieldLabel>
                   <TiptapEditor
                     ref={editorRef}
+                    siteId={siteId}
                     content={post.contentJson || undefined}
                     onEditorReady={handleEditorReady}
                   />

--- a/app/(app)/admin/[siteId]/posts/new/page.tsx
+++ b/app/(app)/admin/[siteId]/posts/new/page.tsx
@@ -198,7 +198,7 @@ export default function NewPostPage() {
                 {/* 내용 */}
                 <Field>
                   <FieldLabel>내용</FieldLabel>
-                  <TiptapEditor ref={editorRef} />
+                  <TiptapEditor ref={editorRef} siteId={siteId} />
                 </Field>
               </div>
             </div>

--- a/src/components/editor/MenuBar.tsx
+++ b/src/components/editor/MenuBar.tsx
@@ -13,6 +13,7 @@ import { HistoryMenu } from './menu/HistoryMenu';
 
 interface MenuBarProps {
   editor: Editor;
+  siteId: string;
 }
 
 const Separator = () => (
@@ -21,7 +22,7 @@ const Separator = () => (
   </div>
 );
 
-export function MenuBar({ editor }: MenuBarProps) {
+export function MenuBar({ editor, siteId }: MenuBarProps) {
   const editorState = useMenuEditorState(editor);
 
   if (!editorState) {
@@ -30,7 +31,7 @@ export function MenuBar({ editor }: MenuBarProps) {
 
   return (
     <div className="flex flex-wrap items-center gap-0 p-2 border-b bg-muted/30">
-      <MediaMenu editor={editor} />
+      <MediaMenu editor={editor} siteId={siteId} />
       <Separator />
       <LinkMenu editor={editor} editorState={editorState} />
       <Separator />

--- a/src/components/editor/TiptapEditor.tsx
+++ b/src/components/editor/TiptapEditor.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { forwardRef, useImperativeHandle } from 'react';
+import { forwardRef, useImperativeHandle, useCallback, useEffect } from 'react';
 import { useEditor, EditorContent, Editor } from '@tiptap/react';
 import { extensions } from './extensions';
 import { MenuBar } from './MenuBar';
 import { useCharacterCount } from './hooks/useCharacterCount';
+import { useUpload } from '@/hooks/use-upload';
 
 export interface TiptapEditorRef {
   getEditor: () => Editor | null;
@@ -14,12 +15,36 @@ export interface TiptapEditorRef {
 }
 
 interface TiptapEditorProps {
+  siteId: string;
   content?: string | Record<string, unknown>;
   onEditorReady?: (editor: Editor) => void;
 }
 
 export const TiptapEditor = forwardRef<TiptapEditorRef, TiptapEditorProps>(
-  ({ content, onEditorReady }, ref) => {
+  ({ siteId, content, onEditorReady }, ref) => {
+    const { upload, uploadProgress, reset } = useUpload(siteId);
+
+    // 이미지 파일 업로드
+    const handleImageUpload = useCallback(
+      async (file: File) => {
+        // 이미지 파일인지 확인
+        if (!file.type.startsWith('image/')) {
+          return false;
+        }
+
+        // 지원하는 형식인지 확인
+        const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+        if (!allowedTypes.includes(file.type)) {
+          return false;
+        }
+
+        // 업로드 시작
+        await upload(file, { imageType: 'CONTENT' });
+        return true;
+      },
+      [upload],
+    );
+
     const editor = useEditor({
       extensions,
       content: content || undefined,
@@ -30,16 +55,77 @@ export const TiptapEditor = forwardRef<TiptapEditorRef, TiptapEditorProps>(
           class:
             'prose prose-sm sm:prose-base lg:prose-lg max-w-none min-h-[200px] p-4 rounded-br-md rounded-bl-md bg-white focus:outline-none focus:ring-2 focus:ring-ring ring-offset-background placeholder:text-muted-foreground',
         },
+        // 드래그&드롭 핸들러
+        handleDrop: (view, event, _slice, moved) => {
+          if (moved) {
+            return false; // 에디터 내부 이동은 기본 동작 유지
+          }
+
+          const files = event.dataTransfer?.files;
+          if (!files || files.length === 0) {
+            return false;
+          }
+
+          const imageFile = Array.from(files).find((file) => file.type.startsWith('image/'));
+          if (!imageFile) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          // view.state가 유효하면 업로드 시작
+          if (view.state.schema) {
+            handleImageUpload(imageFile);
+          }
+
+          return true;
+        },
+        // 붙여넣기 핸들러
+        handlePaste: (view, event) => {
+          const items = event.clipboardData?.items;
+          if (!items) {
+            return false;
+          }
+
+          const imageItem = Array.from(items).find((item) => item.type.startsWith('image/'));
+          if (!imageItem) {
+            return false;
+          }
+
+          const file = imageItem.getAsFile();
+          if (!file) {
+            return false;
+          }
+
+          event.preventDefault();
+
+          // view.state가 유효하면 업로드 시작
+          if (view.state.schema) {
+            handleImageUpload(file);
+          }
+
+          return true;
+        },
       },
       onUpdate: () => {
         // 에디터 업데이트 시 콜백 호출 (필요한 경우)
       },
     });
 
+    // 업로드 완료 시 에디터에 이미지 삽입
+    useEffect(() => {
+      if (uploadProgress.status === 'completed' && uploadProgress.publicUrl && editor) {
+        editor.chain().focus().setImage({ src: uploadProgress.publicUrl }).run();
+        reset();
+      }
+    }, [uploadProgress.status, uploadProgress.publicUrl, editor, reset]);
+
     // editor가 준비되면 콜백 호출
-    if (editor && onEditorReady) {
-      onEditorReady(editor);
-    }
+    useEffect(() => {
+      if (editor && onEditorReady) {
+        onEditorReady(editor);
+      }
+    }, [editor, onEditorReady]);
 
     useImperativeHandle(ref, () => ({
       getEditor: () => editor,
@@ -77,9 +163,54 @@ export const TiptapEditor = forwardRef<TiptapEditorRef, TiptapEditorProps>(
 
     const { charactersCount, wordsCount } = characterCount;
 
+    // 업로드 중 상태
+    const isUploading =
+      uploadProgress.status === 'presigning' ||
+      uploadProgress.status === 'uploading' ||
+      uploadProgress.status === 'completing';
+
     return (
       <div className="border rounded-md">
-        <MenuBar editor={editor} />
+        <MenuBar editor={editor} siteId={siteId} />
+
+        {/* 업로드 진행 상태 표시 */}
+        {isUploading && (
+          <div className="px-4 py-2 bg-blue-50 border-b border-blue-100">
+            <div className="flex items-center gap-2 text-sm text-blue-700">
+              <div className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+              {uploadProgress.status === 'presigning' && <span>업로드 준비 중...</span>}
+              {uploadProgress.status === 'uploading' && (
+                <span>업로드 중... {uploadProgress.progress}%</span>
+              )}
+              {uploadProgress.status === 'completing' && <span>업로드 완료 처리 중...</span>}
+            </div>
+            {uploadProgress.status === 'uploading' && (
+              <div className="mt-1 w-full bg-blue-200 rounded-full h-1.5">
+                <div
+                  className="bg-blue-500 h-1.5 rounded-full transition-all duration-300"
+                  style={{ width: `${uploadProgress.progress}%` }}
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 업로드 에러 표시 */}
+        {uploadProgress.status === 'error' && uploadProgress.error && (
+          <div className="px-4 py-2 bg-red-50 border-b border-red-100">
+            <div className="flex items-center justify-between text-sm text-red-700">
+              <span>{uploadProgress.error}</span>
+              <button
+                type="button"
+                onClick={reset}
+                className="text-red-500 hover:text-red-700 font-medium"
+              >
+                닫기
+              </button>
+            </div>
+          </div>
+        )}
+
         <EditorContent editor={editor} />
         <div className="p-2 border-t border-border">
           <span className="text-xs text-muted-foreground">

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -1,10 +1,10 @@
 import StarterKit from '@tiptap/starter-kit';
 import { TextStyleKit } from '@tiptap/extension-text-style';
 import { Placeholder, CharacterCount, Dropcursor } from '@tiptap/extensions';
-import Image from '@tiptap/extension-image';
 import Emoji, { gitHubEmojis } from '@tiptap/extension-emoji';
 import Youtube from '@tiptap/extension-youtube';
 import { linkExtension } from './config/link-config';
+import { ResizableImage } from './extensions/ResizableImage';
 
 export const extensions = [
   TextStyleKit,
@@ -13,7 +13,7 @@ export const extensions = [
     placeholder: '내용을 입력해주세요.',
   }),
   CharacterCount.configure({}),
-  Image,
+  ResizableImage,
   Dropcursor,
   Emoji.configure({
     emojis: gitHubEmojis,

--- a/src/components/editor/extensions/ResizableImage.tsx
+++ b/src/components/editor/extensions/ResizableImage.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import Image from '@tiptap/extension-image';
+import { NodeViewWrapper, NodeViewProps, ReactNodeViewRenderer } from '@tiptap/react';
+import { useState, useCallback, useRef, useEffect } from 'react';
+
+// 이미지 리사이즈 컴포넌트
+function ResizableImageComponent({ node, updateAttributes, selected }: NodeViewProps) {
+  const { src, alt, width, height } = node.attrs;
+  const [isResizing, setIsResizing] = useState(false);
+  const [startPos, setStartPos] = useState({ x: 0, y: 0 });
+  const [startSize, setStartSize] = useState({ width: 0, height: 0 });
+  const [imageSize, setImageSize] = useState({ width: 0, height: 0 });
+  const imageRef = useRef<HTMLImageElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // 이미지 로드 시 사이즈 업데이트
+  const handleImageLoad = useCallback(() => {
+    if (imageRef.current) {
+      setImageSize({
+        width: imageRef.current.offsetWidth,
+        height: imageRef.current.offsetHeight,
+      });
+    }
+  }, []);
+
+  // 리사이즈 시작
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const img = imageRef.current;
+    if (!img) return;
+
+    setIsResizing(true);
+    setStartPos({ x: e.clientX, y: e.clientY });
+    setStartSize({ width: img.offsetWidth, height: img.offsetHeight });
+  }, []);
+
+  // 리사이즈 중
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const deltaX = e.clientX - startPos.x;
+      const newWidth = Math.max(100, startSize.width + deltaX);
+      const aspectRatio = startSize.height / startSize.width;
+      const newHeight = Math.round(newWidth * aspectRatio);
+
+      updateAttributes({
+        width: newWidth,
+        height: newHeight,
+      });
+    };
+
+    const handleMouseUp = () => {
+      setIsResizing(false);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isResizing, startPos, startSize, updateAttributes]);
+
+  return (
+    <NodeViewWrapper className="relative inline-block">
+      <div
+        ref={containerRef}
+        className={`relative inline-block ${selected ? 'ring-2 ring-blue-500 ring-offset-2' : ''}`}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          ref={imageRef}
+          src={src}
+          alt={alt || ''}
+          width={width || undefined}
+          height={height || undefined}
+          className="max-w-full h-auto block"
+          style={{
+            width: width ? `${width}px` : undefined,
+            height: height ? `${height}px` : undefined,
+          }}
+          draggable={false}
+          onLoad={handleImageLoad}
+        />
+
+        {/* 리사이즈 핸들 - 선택 시에만 표시 */}
+        {selected && (
+          <>
+            {/* 우하단 핸들 */}
+            <div
+              className="absolute bottom-0 right-0 w-4 h-4 bg-blue-500 cursor-se-resize rounded-sm transform translate-x-1/2 translate-y-1/2 hover:bg-blue-600 transition-colors z-10"
+              onMouseDown={handleResizeStart}
+            />
+            {/* 사이즈 표시 */}
+            <div className="absolute bottom-2 left-2 bg-black/70 text-white text-xs px-2 py-1 rounded pointer-events-none">
+              {Math.round(width || imageSize.width || 0)} ×{' '}
+              {Math.round(height || imageSize.height || 0)}
+            </div>
+          </>
+        )}
+
+        {/* 리사이징 중일 때 오버레이 */}
+        {isResizing && (
+          <div className="absolute inset-0 bg-blue-500/10 pointer-events-none" />
+        )}
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// 리사이저블 이미지 익스텐션 - 기본 Image 확장을 확장
+export const ResizableImage = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (element) => {
+          const width = element.getAttribute('width');
+          return width ? parseInt(width, 10) : null;
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.width) {
+            return {};
+          }
+          return { width: attributes.width };
+        },
+      },
+      height: {
+        default: null,
+        parseHTML: (element) => {
+          const height = element.getAttribute('height');
+          return height ? parseInt(height, 10) : null;
+        },
+        renderHTML: (attributes) => {
+          if (!attributes.height) {
+            return {};
+          }
+          return { height: attributes.height };
+        },
+      },
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ResizableImageComponent);
+  },
+});

--- a/src/components/editor/menu/media/ImageInsertButton.tsx
+++ b/src/components/editor/menu/media/ImageInsertButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -12,12 +12,36 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { Image } from 'lucide-react';
+import { Image, Upload } from 'lucide-react';
 import { Editor } from '@tiptap/react';
+import { useUpload } from '@/hooks/use-upload';
+import { cn } from '@/lib/utils';
 
-export function ImageInsertButton({ editor }: { editor: Editor }) {
+type InputMode = 'url' | 'upload';
+
+interface ImageInsertButtonProps {
+  editor: Editor;
+  siteId: string;
+}
+
+export function ImageInsertButton({ editor, siteId }: ImageInsertButtonProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [imageUrl, setImageUrl] = useState('');
+  const [mode, setMode] = useState<InputMode>('upload');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const { upload, uploadProgress, reset, isUploading } = useUpload(siteId);
+
+  // 업로드 완료 시 에디터에 이미지 삽입
+  useEffect(() => {
+    if (uploadProgress.status === 'completed' && uploadProgress.publicUrl) {
+      editor?.chain().focus().setImage({ src: uploadProgress.publicUrl }).run();
+      reset();
+      // 다음 프레임에 모달 닫기 (cascading render 방지)
+      requestAnimationFrame(() => {
+        setIsModalOpen(false);
+      });
+    }
+  }, [uploadProgress.status, uploadProgress.publicUrl, editor, reset]);
 
   const handleAddImage = useCallback(() => {
     if (imageUrl.trim()) {
@@ -27,46 +51,167 @@ export function ImageInsertButton({ editor }: { editor: Editor }) {
     }
   }, [editor, imageUrl]);
 
+  const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      await upload(file, { imageType: 'CONTENT' });
+    } catch (error) {
+      console.error('Upload failed:', error);
+    }
+
+    // 파일 입력 초기화
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const handleModalClose = (open: boolean) => {
+    if (!open && !isUploading) {
+      setIsModalOpen(false);
+      setImageUrl('');
+      reset();
+    }
+  };
+
   return (
     <>
       <Button
         variant="ghost"
         size="icon-sm"
         onClick={() => setIsModalOpen(true)}
-        title="이미지 삽입(url)"
+        title="이미지 삽입"
       >
         <Image className="h-4 w-4" aria-label="Set image" />
       </Button>
 
-      <AlertDialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+      <AlertDialog open={isModalOpen} onOpenChange={handleModalClose}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>이미지 추가</AlertDialogTitle>
-            <AlertDialogDescription>이미지 URL을 입력하세요.</AlertDialogDescription>
+            <AlertDialogDescription>
+              파일을 업로드하거나 URL을 입력하세요.
+            </AlertDialogDescription>
           </AlertDialogHeader>
-          <div className="space-y-4 py-4">
-            <div className="space-y-2">
-              <Label htmlFor="image-url">이미지 URL</Label>
-              <Input
-                id="image-url"
-                type="url"
-                placeholder="https://example.com/image.jpg"
-                value={imageUrl}
-                onChange={(e) => setImageUrl(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleAddImage();
-                  }
-                }}
-                autoFocus
-              />
-            </div>
+
+          {/* 모드 선택 탭 */}
+          <div className="flex gap-2 border-b pb-2">
+            <Button
+              type="button"
+              variant={mode === 'upload' ? 'default' : 'ghost'}
+              size="sm"
+              onClick={() => setMode('upload')}
+              disabled={isUploading}
+            >
+              <Upload className="w-4 h-4 mr-1" />
+              파일 업로드
+            </Button>
+            <Button
+              type="button"
+              variant={mode === 'url' ? 'default' : 'ghost'}
+              size="sm"
+              onClick={() => setMode('url')}
+              disabled={isUploading}
+            >
+              URL 입력
+            </Button>
           </div>
+
+          <div className="space-y-4 py-4">
+            {/* 파일 업로드 모드 */}
+            {mode === 'upload' && (
+              <div className="space-y-4">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  onChange={handleFileSelect}
+                  disabled={isUploading}
+                  className="hidden"
+                />
+
+                {/* 업로드 진행 상태 */}
+                {isUploading ? (
+                  <div className="space-y-3">
+                    <div className="flex items-center gap-2 text-sm text-gray-600">
+                      <div className="w-4 h-4 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+                      {uploadProgress.status === 'presigning' && <span>업로드 준비 중...</span>}
+                      {uploadProgress.status === 'uploading' && (
+                        <span>업로드 중... {uploadProgress.progress}%</span>
+                      )}
+                      {uploadProgress.status === 'completing' && (
+                        <span>업로드 완료 처리 중...</span>
+                      )}
+                    </div>
+                    {uploadProgress.status === 'uploading' && (
+                      <div className="w-full bg-gray-200 rounded-full h-2">
+                        <div
+                          className="bg-blue-500 h-2 rounded-full transition-all duration-300"
+                          style={{ width: `${uploadProgress.progress}%` }}
+                        />
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div
+                    className={cn(
+                      'flex flex-col items-center justify-center border-2 border-dashed rounded-lg p-8 cursor-pointer transition-colors',
+                      'hover:border-blue-400 hover:bg-blue-50',
+                      uploadProgress.status === 'error'
+                        ? 'border-red-300 bg-red-50'
+                        : 'border-gray-300',
+                    )}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <Upload className="w-10 h-10 text-gray-400 mb-2" />
+                    <p className="text-sm text-gray-600 text-center">
+                      클릭하여 이미지 선택
+                      <br />
+                      <span className="text-xs text-gray-400">
+                        JPEG, PNG, WebP (최대 2MB)
+                      </span>
+                    </p>
+                  </div>
+                )}
+
+                {/* 에러 메시지 */}
+                {uploadProgress.status === 'error' && uploadProgress.error && (
+                  <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-700 text-sm">
+                    {uploadProgress.error}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* URL 모드 */}
+            {mode === 'url' && (
+              <div className="space-y-2">
+                <Label htmlFor="image-url">이미지 URL</Label>
+                <Input
+                  id="image-url"
+                  type="url"
+                  placeholder="https://example.com/image.jpg"
+                  value={imageUrl}
+                  onChange={(e) => setImageUrl(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleAddImage();
+                    }
+                  }}
+                  autoFocus
+                />
+              </div>
+            )}
+          </div>
+
           <AlertDialogFooter>
-            <AlertDialogCancel>취소</AlertDialogCancel>
-            <AlertDialogAction onClick={handleAddImage} disabled={!imageUrl.trim()}>
-              추가
-            </AlertDialogAction>
+            <AlertDialogCancel disabled={isUploading}>취소</AlertDialogCancel>
+            {mode === 'url' && (
+              <AlertDialogAction onClick={handleAddImage} disabled={!imageUrl.trim()}>
+                추가
+              </AlertDialogAction>
+            )}
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/src/components/editor/menu/media/MediaMenu.tsx
+++ b/src/components/editor/menu/media/MediaMenu.tsx
@@ -2,11 +2,16 @@ import { Editor } from '@tiptap/react';
 import { YoutubeInsertButton } from './YoutubeInsertButton';
 import { ImageInsertButton } from './ImageInsertButton';
 
-export function MediaMenu({ editor }: { editor: Editor }) {
+interface MediaMenuProps {
+  editor: Editor;
+  siteId: string;
+}
+
+export function MediaMenu({ editor, siteId }: MediaMenuProps) {
   return (
     <div className="flex items-center gap-2 pr-2 mr-2">
       <YoutubeInsertButton editor={editor} />
-      <ImageInsertButton editor={editor} />
+      <ImageInsertButton editor={editor} siteId={siteId} />
     </div>
   );
 }


### PR DESCRIPTION
Phase 1: siteId props 체인 + 버튼 클릭 업로드
- TiptapEditor에 siteId props 추가
- MenuBar, MediaMenu, ImageInsertButton으로 siteId 전달
- ImageInsertButton에 파일 업로드 탭 UI 추가

Phase 2: 드래그앤드롭, 붙여넣기 지원
- editorProps.handleDrop으로 이미지 드래그앤드롭 자동 업로드
- editorProps.handlePaste로 클립보드 이미지 붙여넣기 자동 업로드
- 업로드 진행률 UI 표시

Phase 3: 이미지 리사이징 UI
- ResizableImage 커스텀 확장 추가
- 이미지 클릭 시 리사이즈 핸들 및 사이즈 표시
- 드래그로 이미지 크기 조절 (비율 유지)

Closes #26