### PR TITLE
feat: 게시글 상세 페이지 리디자인 및 삭제/비공개 기능

### DIFF
--- a/app/(app)/admin/[siteId]/posts/[postId]/page.tsx
+++ b/app/(app)/admin/[siteId]/posts/[postId]/page.tsx
@@ -1,20 +1,45 @@
 'use client';
 
 import { useParams, useRouter } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
-import { getAdminPost, PostStatus } from '@/lib/api';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getAdminPost, PostStatus, revalidatePost } from '@/lib/api';
 import { PostContent } from '@/components/post/PostContent';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 import { formatPostDate } from '@/lib/date-utils';
-import { Pencil, ExternalLink } from 'lucide-react';
+import {
+  Pencil,
+  ExternalLink,
+  Trash2,
+  Eye,
+  EyeOff,
+  FileText,
+  AlertTriangle,
+  Lock,
+} from 'lucide-react';
 import { AdminPageHeader } from '@/components/layout/AdminPageHeader';
 import { useAdminSiteSettings } from '@/hooks/use-site-settings';
+import { useDeletePost, useUpdatePostStatus } from '@/hooks/use-posts';
+import { useState } from 'react';
 
 export default function AdminPostDetailPage() {
   const params = useParams<{ siteId: string; postId: string }>();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { siteId, postId } = params;
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const {
     data: post,
@@ -27,6 +52,8 @@ export default function AdminPostDetailPage() {
   });
 
   const { data: siteSettings } = useAdminSiteSettings(siteId);
+  const deletePostMutation = useDeletePost(siteId);
+  const updateStatusMutation = useUpdatePostStatus(siteId, postId);
 
   const formattedDate = post ? formatPostDate(post.createdAt) : '';
   const publishedDate = post?.publishedAt ? formatPostDate(post.publishedAt) : null;
@@ -38,10 +65,96 @@ export default function AdminPostDetailPage() {
       ? `https://${siteSettings.slug}.${tenantDomain}/posts/${post.slug}`
       : null;
 
+  // 상태 배너 정보
+  const getBannerInfo = () => {
+    if (!post) return null;
+    if (post.status === PostStatus.DRAFT) {
+      return {
+        icon: FileText,
+        message: '이 게시글은 현재 초안 상태이며 공개되지 않습니다.',
+        action: '지금 발행',
+        actionStatus: PostStatus.PUBLISHED,
+        bgColor: 'bg-amber-50 border-amber-200',
+        textColor: 'text-amber-800',
+        iconColor: 'text-amber-500',
+      };
+    }
+    if (post.status === PostStatus.PRIVATE) {
+      return {
+        icon: Lock,
+        message: '이 게시글은 현재 비공개 상태입니다.',
+        action: '공개로 전환',
+        actionStatus: PostStatus.PUBLISHED,
+        bgColor: 'bg-blue-50 border-blue-200',
+        textColor: 'text-blue-800',
+        iconColor: 'text-blue-500',
+      };
+    }
+    return null;
+  };
+
+  const bannerInfo = getBannerInfo();
+
+  // 상태 뱃지 스타일
+  const getStatusBadge = () => {
+    if (!post) return null;
+    switch (post.status) {
+      case PostStatus.PUBLISHED:
+        return (
+          <Badge className="bg-green-100 text-green-800 hover:bg-green-100">
+            <Eye className="w-3 h-3 mr-1" />
+            발행됨
+          </Badge>
+        );
+      case PostStatus.PRIVATE:
+        return (
+          <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100">
+            <Lock className="w-3 h-3 mr-1" />
+            비공개
+          </Badge>
+        );
+      default:
+        return (
+          <Badge className="bg-yellow-100 text-yellow-800 hover:bg-yellow-100">
+            <FileText className="w-3 h-3 mr-1" />
+            임시저장
+          </Badge>
+        );
+    }
+  };
+
+  // 삭제 핸들러
+  const handleDelete = async () => {
+    if (!post || !siteSettings) return;
+    setIsDeleting(true);
+    try {
+      await deletePostMutation.mutateAsync(postId);
+      // ISR 캐시 무효화
+      await revalidatePost(siteSettings.slug, post.slug);
+      router.push(`/admin/${siteId}/posts`);
+    } catch (error) {
+      console.error('Failed to delete post:', error);
+      setIsDeleting(false);
+    }
+  };
+
+  // 상태 변경 핸들러
+  const handleStatusChange = async (newStatus: PostStatus) => {
+    if (!post || !siteSettings) return;
+    try {
+      await updateStatusMutation.mutateAsync({ status: newStatus });
+      // ISR 캐시 무효화
+      await revalidatePost(siteSettings.slug, post.slug);
+      queryClient.invalidateQueries({ queryKey: ['admin', 'post', siteId, postId] });
+    } catch (error) {
+      console.error('Failed to update status:', error);
+    }
+  };
+
   if (isLoading) {
     return (
       <>
-        <AdminPageHeader breadcrumb="Posts" title="Post Detail" />
+        <AdminPageHeader breadcrumb="Posts" title="게시글 상세" />
         <div className="p-8">
           <div className="animate-pulse space-y-6">
             <div className="h-8 bg-gray-200 rounded w-1/4"></div>
@@ -57,7 +170,7 @@ export default function AdminPostDetailPage() {
   if (error || !post) {
     return (
       <>
-        <AdminPageHeader breadcrumb="Posts" title="Post Detail" />
+        <AdminPageHeader breadcrumb="Posts" title="게시글 상세" />
         <div className="p-8">
           <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
             <p className="text-red-700 mb-4">게시글을 찾을 수 없습니다.</p>
@@ -72,109 +185,223 @@ export default function AdminPostDetailPage() {
 
   return (
     <>
+      {/* 상태 배너 (Draft/Private) */}
+      {bannerInfo && (
+        <div
+          className={`border-b px-4 py-3 flex items-center justify-between ${bannerInfo.bgColor}`}
+        >
+          <div className="flex items-center gap-2">
+            <bannerInfo.icon className={`w-4 h-4 ${bannerInfo.iconColor}`} />
+            <span className={`text-sm font-medium ${bannerInfo.textColor}`}>
+              {bannerInfo.message}
+            </span>
+          </div>
+          {post.status !== PostStatus.DRAFT && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => handleStatusChange(bannerInfo.actionStatus)}
+              disabled={updateStatusMutation.isPending}
+              className={`${bannerInfo.textColor} border-current hover:bg-white/50`}
+            >
+              {bannerInfo.action}
+            </Button>
+          )}
+          {post.status === PostStatus.DRAFT && (
+            <Button
+              size="sm"
+              onClick={() => handleStatusChange(PostStatus.PUBLISHED)}
+              disabled={updateStatusMutation.isPending}
+              className="bg-amber-600 hover:bg-amber-700 text-white"
+            >
+              지금 발행
+            </Button>
+          )}
+        </div>
+      )}
+
       <AdminPageHeader
         breadcrumb="Posts"
-        title={post.title || 'Post Detail'}
+        title={post.title || '(제목없음)'}
         action={{
           label: '편집',
           href: `/admin/${siteId}/posts/${postId}/edit`,
           icon: Pencil,
         }}
-        extra={
-          <div className="flex items-center gap-2 text-sm text-gray-500">
-            <Badge
-              variant={post.status === PostStatus.PUBLISHED ? 'default' : 'secondary'}
-              className={
-                post.status === PostStatus.PUBLISHED
-                  ? 'bg-green-100 text-green-800 hover:bg-green-100'
-                  : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-100'
-              }
-            >
-              {post.status === PostStatus.PUBLISHED ? '발행됨' : '임시저장'}
-            </Badge>
-            <span>·</span>
-            <span>작성: {formattedDate}</span>
-            {publishedDate && (
-              <>
-                <span>·</span>
-                <span>발행: {publishedDate}</span>
-              </>
-            )}
-            {blogPostUrl && (
-              <>
-                <span>·</span>
-                <a
-                  href={blogPostUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-primary hover:underline"
-                >
-                  <ExternalLink className="w-3 h-3" />
-                  블로그에서 보기
-                </a>
-              </>
-            )}
-          </div>
-        }
       />
-      <div className="bg-gray-50">
-        {/* 메인 콘텐츠 */}
-        <div className="max-w-5xl mx-auto px-4 py-8">
-          {/* 메타 정보 카드 */}
-          <div className="bg-white rounded-lg border border-gray-200 p-6 mb-8">
-            <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-4">
-              게시글 정보
-            </h2>
-            <dl className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-              <div>
-                <dt className="text-gray-500">Slug</dt>
-                <dd className="font-mono text-gray-900 mt-1">/{post.slug}</dd>
-              </div>
-              <div>
-                <dt className="text-gray-500">상태</dt>
-                <dd className="mt-1">
-                  {post.status === PostStatus.PUBLISHED ? '발행됨' : '임시저장'}
-                </dd>
-              </div>
-              <div>
-                <dt className="text-gray-500">작성일</dt>
-                <dd className="text-gray-900 mt-1">{formattedDate}</dd>
-              </div>
-              <div>
-                <dt className="text-gray-500">발행일</dt>
-                <dd className="text-gray-900 mt-1">{publishedDate || '-'}</dd>
-              </div>
-            </dl>
-          </div>
 
-          {/* 썸네일 */}
-          {post.ogImageUrl && (
-            <div className="mb-8">
-              <div className="aspect-video rounded-lg overflow-hidden bg-gray-100">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  src={post.ogImageUrl}
-                  alt={post.title || '썸네일'}
-                  className="w-full h-full object-cover"
-                />
+      <div className="bg-gray-50 min-h-[calc(100vh-120px)]">
+        <div className="max-w-7xl mx-auto px-4 py-8">
+          <div className="flex flex-col lg:flex-row gap-8">
+            {/* 좌측: 메인 콘텐츠 */}
+            <div className="flex-1 min-w-0">
+              {/* 썸네일 */}
+              {post.ogImageUrl && (
+                <div className="mb-6">
+                  <div className="aspect-video rounded-lg overflow-hidden bg-gray-100 shadow-sm">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={post.ogImageUrl}
+                      alt={post.title || '썸네일'}
+                      className="w-full h-full object-cover"
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* 제목 및 날짜 */}
+              <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6 shadow-sm">
+                <h1 className="text-3xl font-bold text-gray-900 mb-3">
+                  {post.title || <span className="text-gray-400">(제목없음)</span>}
+                </h1>
+                {post.subtitle && (
+                  <p className="text-lg text-gray-600 mb-4">{post.subtitle}</p>
+                )}
+                <div className="flex items-center gap-3 text-sm text-gray-500">
+                  <span>작성: {formattedDate}</span>
+                  {publishedDate && (
+                    <>
+                      <span>·</span>
+                      <span>발행: {publishedDate}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {/* 본문 */}
+              <div className="bg-white rounded-lg border border-gray-200 p-6 shadow-sm">
+                <PostContent html={post.contentHtml} />
               </div>
             </div>
-          )}
 
-          {/* 제목 및 부제목 */}
-          <div className="bg-white rounded-lg border border-gray-200 p-6 mb-8">
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">
-              {post.title || <span className="text-gray-400">(제목없음)</span>}
-            </h1>
-            {post.subtitle && <p className="text-lg text-gray-600">{post.subtitle}</p>}
-          </div>
+            {/* 우측: 사이드바 */}
+            <div className="w-full lg:w-80 shrink-0">
+              <div className="bg-white rounded-lg border border-gray-200 shadow-sm sticky top-4">
+                {/* 게시글 정보 */}
+                <div className="p-4">
+                  <h3 className="text-sm font-semibold text-gray-900 mb-4">게시글 정보</h3>
+                  <dl className="space-y-3 text-sm">
+                    <div className="flex justify-between items-center">
+                      <dt className="text-gray-500">상태</dt>
+                      <dd>{getStatusBadge()}</dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt className="text-gray-500">Slug</dt>
+                      <dd className="font-mono text-gray-900 text-right truncate max-w-[180px]">
+                        /{post.slug}
+                      </dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt className="text-gray-500">작성일</dt>
+                      <dd className="text-gray-900">{formattedDate}</dd>
+                    </div>
+                    <div className="flex justify-between">
+                      <dt className="text-gray-500">발행일</dt>
+                      <dd className="text-gray-900">{publishedDate || '-'}</dd>
+                    </div>
+                  </dl>
+                </div>
 
-          {/* 본문 */}
-          <div className="bg-white rounded-lg border border-gray-200 p-6">
-            <h2 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-4">
-              본문
-            </h2>
-            <PostContent html={post.contentHtml} />
+                <Separator />
+
+                {/* 작업 버튼들 */}
+                <div className="p-4 space-y-2">
+                  <h3 className="text-sm font-semibold text-gray-900 mb-3">작업</h3>
+
+                  {/* 편집 */}
+                  <Button
+                    variant="outline"
+                    className="w-full justify-start"
+                    onClick={() => router.push(`/admin/${siteId}/posts/${postId}/edit`)}
+                  >
+                    <Pencil className="w-4 h-4 mr-2" />
+                    게시글 편집
+                  </Button>
+
+                  {/* 블로그에서 보기 (PUBLISHED일 때만) */}
+                  {blogPostUrl && (
+                    <Button variant="outline" className="w-full justify-start" asChild>
+                      <a href={blogPostUrl} target="_blank" rel="noopener noreferrer">
+                        <ExternalLink className="w-4 h-4 mr-2" />
+                        블로그에서 보기
+                      </a>
+                    </Button>
+                  )}
+
+                  {/* 상태 변경 버튼 */}
+                  {post.status === PostStatus.PUBLISHED && (
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start"
+                      onClick={() => handleStatusChange(PostStatus.PRIVATE)}
+                      disabled={updateStatusMutation.isPending}
+                    >
+                      <EyeOff className="w-4 h-4 mr-2" />
+                      비공개로 전환
+                    </Button>
+                  )}
+                  {post.status === PostStatus.PRIVATE && (
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start"
+                      onClick={() => handleStatusChange(PostStatus.PUBLISHED)}
+                      disabled={updateStatusMutation.isPending}
+                    >
+                      <Eye className="w-4 h-4 mr-2" />
+                      공개로 전환
+                    </Button>
+                  )}
+                  {post.status === PostStatus.DRAFT && (
+                    <Button
+                      variant="outline"
+                      className="w-full justify-start"
+                      onClick={() => handleStatusChange(PostStatus.PUBLISHED)}
+                      disabled={updateStatusMutation.isPending}
+                    >
+                      <Eye className="w-4 h-4 mr-2" />
+                      발행하기
+                    </Button>
+                  )}
+
+                  <Separator className="my-3" />
+
+                  {/* 삭제 */}
+                  <AlertDialog>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="w-full justify-start text-red-600 hover:text-red-700 hover:bg-red-50 border-red-200"
+                      >
+                        <Trash2 className="w-4 h-4 mr-2" />
+                        게시글 삭제
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle className="flex items-center gap-2">
+                          <AlertTriangle className="w-5 h-5 text-red-500" />
+                          게시글을 삭제하시겠습니까?
+                        </AlertDialogTitle>
+                        <AlertDialogDescription>
+                          이 작업은 되돌릴 수 없습니다. 게시글과 관련된 모든 데이터가 영구적으로
+                          삭제됩니다.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>취소</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={handleDelete}
+                          disabled={isDeleting}
+                          className="bg-red-600 hover:bg-red-700"
+                        >
+                          {isDeleting ? '삭제 중...' : '삭제'}
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/(app)/admin/[siteId]/posts/page.tsx
+++ b/app/(app)/admin/[siteId]/posts/page.tsx
@@ -144,10 +144,16 @@ export default function AdminPostsPage() {
                         className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                           post.status === PostStatus.PUBLISHED
                             ? 'bg-green-100 text-green-800'
-                            : 'bg-yellow-100 text-yellow-800'
+                            : post.status === PostStatus.PRIVATE
+                              ? 'bg-blue-100 text-blue-800'
+                              : 'bg-yellow-100 text-yellow-800'
                         }`}
                       >
-                        {post.status === PostStatus.PUBLISHED ? '발행됨' : '임시저장'}
+                        {post.status === PostStatus.PUBLISHED
+                          ? '발행됨'
+                          : post.status === PostStatus.PRIVATE
+                            ? '비공개'
+                            : '임시저장'}
                       </span>
                     </td>
                     <td className="px-6 py-4 text-sm text-gray-500">

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,77 @@
+import { revalidatePath, revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * On-Demand Revalidation API
+ * POST /api/revalidate
+ *
+ * Body:
+ * - siteSlug: 사이트 slug
+ * - postSlug?: 게시글 slug (없으면 사이트 전체 revalidate)
+ * - secret?: 보안 토큰 (production에서 사용)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { siteSlug, postSlug, secret } = body;
+
+    console.log('[Revalidate] Request received:', { siteSlug, postSlug });
+
+    // Production에서는 secret 검증 (optional)
+    const revalidateSecret = process.env.REVALIDATE_SECRET;
+    if (revalidateSecret && secret !== revalidateSecret) {
+      console.log('[Revalidate] Invalid secret');
+      return NextResponse.json({ error: 'Invalid secret' }, { status: 401 });
+    }
+
+    if (!siteSlug) {
+      return NextResponse.json({ error: 'siteSlug is required' }, { status: 400 });
+    }
+
+    // 캐시 무효화할 경로들
+    const pathsToRevalidate: string[] = [];
+    const tagsToRevalidate: string[] = [];
+
+    if (postSlug) {
+      // 특정 게시글 관련 경로
+      pathsToRevalidate.push(`/t/${siteSlug}/posts/${postSlug}`);
+      pathsToRevalidate.push(`/t/${siteSlug}/posts`);
+      pathsToRevalidate.push(`/t/${siteSlug}`);
+      // 데이터 캐시 태그
+      tagsToRevalidate.push(`post-${siteSlug}-${postSlug}`);
+      tagsToRevalidate.push(`posts-${siteSlug}`);
+    } else {
+      // 사이트 전체 관련 경로
+      pathsToRevalidate.push(`/t/${siteSlug}`);
+      pathsToRevalidate.push(`/t/${siteSlug}/posts`);
+      // 데이터 캐시 태그
+      tagsToRevalidate.push(`posts-${siteSlug}`);
+    }
+
+    // 데이터 캐시 무효화 (태그 기반)
+    // expire: 0 = 즉시 만료 (SWR 없이 바로 적용)
+    for (const tag of tagsToRevalidate) {
+      console.log('[Revalidate] Revalidating tag:', tag);
+      revalidateTag(tag, { expire: 0 });
+    }
+
+    // 페이지 캐시 무효화 (경로 기반)
+    // 동적 세그먼트가 있는 경로는 'page' 타입 지정
+    for (const path of pathsToRevalidate) {
+      console.log('[Revalidate] Revalidating path:', path);
+      revalidatePath(path, 'page');
+    }
+
+    console.log('[Revalidate] Success - tags:', tagsToRevalidate, 'paths:', pathsToRevalidate);
+
+    return NextResponse.json({
+      success: true,
+      revalidatedTags: tagsToRevalidate,
+      revalidatedPaths: pathsToRevalidate,
+      timestamp: Date.now(),
+    });
+  } catch (error) {
+    console.error('[Revalidate] Error:', error);
+    return NextResponse.json({ error: 'Failed to revalidate' }, { status: 500 });
+  }
+}

--- a/src/components/editor/extensions/ResizableImage.tsx
+++ b/src/components/editor/extensions/ResizableImage.tsx
@@ -105,9 +105,7 @@ function ResizableImageComponent({ node, updateAttributes, selected }: NodeViewP
         )}
 
         {/* 리사이징 중일 때 오버레이 */}
-        {isResizing && (
-          <div className="absolute inset-0 bg-blue-500/10 pointer-events-none" />
-        )}
+        {isResizing && <div className="absolute inset-0 bg-blue-500/10 pointer-events-none" />}
       </div>
     </NodeViewWrapper>
   );

--- a/src/hooks/use-posts.ts
+++ b/src/hooks/use-posts.ts
@@ -5,7 +5,10 @@ import {
   createAdminPost,
   getAdminPosts,
   getPublicPosts,
+  deleteAdminPost,
+  updateAdminPost,
   CreatePostRequest,
+  UpdatePostRequest,
   PostListItem,
   PublicPost,
 } from '@/lib/api';
@@ -48,6 +51,43 @@ export function useCreatePost(siteId: string) {
     onError: (error: AxiosError<{ message?: string; code?: string }>) => {
       // 에러는 컴포넌트에서 처리
       console.error('Failed to create post:', error.response?.data);
+    },
+  });
+}
+
+/**
+ * 게시글 삭제 mutation 훅
+ */
+export function useDeletePost(siteId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: string) => deleteAdminPost(siteId, postId),
+    onSuccess: () => {
+      // 게시글 목록 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: postKeys.adminList(siteId) });
+    },
+    onError: (error: AxiosError<{ message?: string; code?: string }>) => {
+      console.error('Failed to delete post:', error.response?.data);
+    },
+  });
+}
+
+/**
+ * 게시글 상태 변경 mutation 훅
+ */
+export function useUpdatePostStatus(siteId: string, postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdatePostRequest) => updateAdminPost(siteId, postId, data),
+    onSuccess: () => {
+      // 게시글 목록 및 단일 게시글 캐시 무효화
+      queryClient.invalidateQueries({ queryKey: postKeys.adminList(siteId) });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'post', siteId, postId] });
+    },
+    onError: (error: AxiosError<{ message?: string; code?: string }>) => {
+      console.error('Failed to update post status:', error.response?.data);
     },
   });
 }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -208,6 +208,33 @@ export async function updateAdminPost(
   return response.data.data;
 }
 
+export async function deleteAdminPost(siteId: string, postId: string): Promise<void> {
+  await api.delete(`/admin/sites/${siteId}/posts/${postId}`);
+}
+
+// ===== Revalidation API =====
+
+/**
+ * ISR 캐시 무효화 요청
+ * 게시글 상태 변경, 삭제 시 호출
+ */
+export async function revalidatePost(siteSlug: string, postSlug?: string): Promise<void> {
+  try {
+    await fetch('/api/revalidate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        siteSlug,
+        postSlug,
+        secret: process.env.NEXT_PUBLIC_REVALIDATE_SECRET,
+      }),
+    });
+  } catch (error) {
+    // Revalidation 실패해도 주요 작업에는 영향 없음
+    console.warn('Failed to revalidate:', error);
+  }
+}
+
 // ===== Public Post API (클라이언트) =====
 
 export async function getPublicPosts(

--- a/src/lib/api/server.ts
+++ b/src/lib/api/server.ts
@@ -19,7 +19,12 @@ export async function fetchPublicPosts(
     params.append('categorySlug', categorySlug);
   }
   const res = await fetch(`${API_BASE_URL}/public/posts?${params.toString()}`, {
-    next: { revalidate: 60 }, // ISR: 60초
+    next: {
+      revalidate: 60,
+      tags: [`posts-${siteSlug}`, categorySlug ? `posts-${siteSlug}-${categorySlug}` : ''].filter(
+        Boolean,
+      ),
+    },
   });
 
   if (!res.ok) {
@@ -39,7 +44,10 @@ export async function fetchPublicPostBySlug(
       siteSlug,
     )}`,
     {
-      next: { revalidate: 60 }, // ISR: 60초
+      next: {
+        revalidate: 60,
+        tags: [`post-${siteSlug}-${postSlug}`, `posts-${siteSlug}`],
+      },
     },
   );
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -15,6 +15,7 @@ export type AccountStatus = (typeof AccountStatus)[keyof typeof AccountStatus];
 export const PostStatus = {
   DRAFT: 'DRAFT',
   PUBLISHED: 'PUBLISHED',
+  PRIVATE: 'PRIVATE', // 발행했지만 비공개
 } as const;
 
 export type PostStatus = (typeof PostStatus)[keyof typeof PostStatus];


### PR DESCRIPTION
## Summary

- 게시글 상세 페이지 2-column 레이아웃으로 리디자인
- 게시글 삭제 기능 추가
- `PRIVATE`(비공개) 상태 추가 및 상태 전환 기능
- On-Demand Revalidation으로 ISR 캐시 즉시 무효화

## Changes

### 게시글 상세 페이지 리디자인
- 좌측: 본문 (썸네일, 제목, 날짜, 내용)
- 우측: 사이드바 (게시글 정보 + 액션 버튼)
- 상단: Draft/Private 상태 배너

### 새 기능
- 게시글 삭제 (확인 다이얼로그 포함)
- 상태 변경 버튼 (발행/비공개 토글)
- `PostStatus.PRIVATE` 추가

### On-Demand Revalidation
- `/api/revalidate` 엔드포인트 추가
- 생성/수정/삭제/상태변경 시 캐시 즉시 무효화
- `revalidateTag` + `revalidatePath` 조합

## Files Changed

- `app/(app)/admin/[siteId]/posts/[postId]/page.tsx` - 상세 페이지 리디자인
- `app/(app)/admin/[siteId]/posts/page.tsx` - 목록에 PRIVATE 상태 표시
- `app/api/revalidate/route.ts` - NEW: Revalidation API
- `src/lib/api/client.ts` - deleteAdminPost, revalidatePost 추가
- `src/lib/api/server.ts` - fetch에 태그 추가
- `src/hooks/use-posts.ts` - 삭제/상태변경 훅 추가

## Test Plan

- [ ] 게시글 상세 페이지 레이아웃 확인
- [ ] 상태 변경 (발행/비공개) 테스트
- [ ] 게시글 삭제 테스트
- [ ] 삭제 확인 다이얼로그 동작 확인
- [ ] ISR 캐시 즉시 무효화 확인

Closes #28